### PR TITLE
Complete docker (compose) example to host a local url-shortener server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *.dll
 *.so
 *.dylib
-
+*.env
 # Test binary, built with `go test -c`
 *.test
 

--- a/examples/docker/docker-compose.yaml
+++ b/examples/docker/docker-compose.yaml
@@ -26,8 +26,10 @@ services:
     volumes:
       - ./nginx-templates:/etc/nginx/templates
     environment:
-      - SERVER_DOMAIN=localhost
-      - URLSHORTENER_SERVER=url-shortener:8000
+      - PROXY_HOST=localhost
+      - BACKEND_HOST=backend:8000
+    depends_on:
+      - backend
     expose:
       - 80
 networks:

--- a/examples/docker/docker-compose.yaml
+++ b/examples/docker/docker-compose.yaml
@@ -1,8 +1,10 @@
-version: '0.1'
+version: '0.2'
+name: url-shortener
 
 services:
-  url-shortener:
+  backend:
     image: url-shortener
+    restart: always
     build:
       context: ../..
       dockerfile: ./docker/Dockerfile
@@ -26,7 +28,9 @@ services:
     environment:
       - SERVER_DOMAIN=localhost
       - URLSHORTENER_SERVER=url-shortener:8000
-      - NGINX_PORT=80
-    ports:
-      - 80:80
-      - 443:443
+    expose:
+      - 80
+networks:
+  default:
+    name: bardbird-network
+    external: true

--- a/examples/docker/docker-compose.yaml
+++ b/examples/docker/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
     expose:
       - 3306
   nginx:
-    image: nginx #:stable-alpine3.19
+    image: nginx:stable-alpine3.19
     restart: always
     volumes:
       - ./nginx-templates:/etc/nginx/templates
@@ -32,7 +32,8 @@ services:
       - backend
     expose:
       - 80
+
 networks:
   default:
-    name: bardbird-network
+    name: ${GATEWAY_NETWORK:-bridge}
     external: true

--- a/examples/docker/docker-run.sh
+++ b/examples/docker/docker-run.sh
@@ -1,2 +1,2 @@
-docker system prune --all --force
+docker system prune -f
 docker compose -f ./examples/docker/docker-compose.yaml up -d --force-recreate #--build

--- a/examples/docker/nginx-templates/default.conf.template
+++ b/examples/docker/nginx-templates/default.conf.template
@@ -2,16 +2,16 @@ server {
     listen       80;
     listen       [::]:80;
     
-    server_name  ${SERVER_DOMAIN};
+    server_name  ${PROXY_HOST};
 
     location ~ "^/[a-zA-Z0-9]{1,7}$" {
       if ($request_method = GET ) {
         rewrite "^/([a-zA-Z0-9]{1,7})$" /api/v1/url/$1 break;
       }
-      proxy_pass http://${URLSHORTENER_SERVER};
+      proxy_pass http://${BACKEND_HOST};
     }
 
     location ~ /.+ {
-      proxy_pass http://${URLSHORTENER_SERVER};
+      proxy_pass http://${BACKEND_HOST};
     }
 }

--- a/examples/docker/nginx-templates/default.conf.template
+++ b/examples/docker/nginx-templates/default.conf.template
@@ -1,5 +1,7 @@
 server {
     listen       80;
+    listen       [::]:80;
+    
     server_name  ${SERVER_DOMAIN};
 
     location ~ "^/[a-zA-Z0-9]{1,7}$" {
@@ -9,7 +11,7 @@ server {
       proxy_pass http://${URLSHORTENER_SERVER};
     }
 
-    location ~/* {
+    location ~ /.+ {
       proxy_pass http://${URLSHORTENER_SERVER};
     }
 }


### PR DESCRIPTION
### write a example to host a simple url-shortener server by docker compose tech

- designed services
    - backend

       golang backend of this feature (build from the current project)

    - mysql

      simple mysql container to host url database

    - nginx
      
      gateway container to do the reverse_proxy and url rewrite (hide the shorten url "READ" api)

- additional design

  if you have a gateway container(docker network) running, like nginx server with https.
  you can join the network by setup the environment variable of `GATEWAY_NETWORK` which called by docker example.

### How to test

You can test this example by
- `sh .\example\docker\docker-run.sh` in windows command line terminal.