### PR TITLE
refactor database setup to yaml config format with environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 # vendor/
 
 .vscode/
+
+*env.cmd

--- a/README.md
+++ b/README.md
@@ -39,19 +39,34 @@ You can just clone the repository.
 ```
 git clone https://github.com/birdmandayum0131/Url_Shortener.git
 ```
-And run the docker compose example.
-```
-sh ./examples/docker/docker-run.sh
-```
-if you have a gateway container(docker network) running, like nginx server with https.
-you can join the network by setup the environment variable of `GATEWAY_NETWORK` which called by docker example.
-
+#### docker
+  run the docker compose example.
+  ```
+  sh ./examples/docker/docker-run.sh
+  ```
+  if you have a gateway container(docker network) running, like nginx server with https.
+  you can join the network by setup the environment variable of `GATEWAY_NETWORK` which called by docker example.
+#### windows
+  If you don't want use docker, and you have a mysql server exist.  
+  
+  1. Setup necessary environment variable or provide a env.cmd under examples/windows.  
+      
+      You can write in format like:
+      ```
+      export DB_USER=${USERNAME}
+      export DB_PASSWORD=${PASSWORD}
+      ```
+  2. run windows example  
+      ```
+      sh ./examples/windows/run.sh
+      ```  
 ## Timeline
   - start the project `2024/04/16`
   - successfully complete the basic implementation `2024/04/18`
   - studying and refactor it to clean architecture ~ `2024/05/09`
   - add docker support to this project `2024/05/10`
   - add docker compose example to Host a URL shortener service from scratch `2024/05/16`
+  - refactor configs to yaml file `2024/05/21`
     
 ## Roadmap
   - [x] Clean Architecture

--- a/configs/database.yaml
+++ b/configs/database.yaml
@@ -1,0 +1,6 @@
+host:     "db"
+port:     3306
+user:     ${DB_USER}
+password: ${DB_PASSWORD}
+database: "url_shortener"
+driver:   "mysql"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,10 @@ RUN ./docker/build.sh && \
 # Remove the project folder after build
 WORKDIR /home/urlserver
 RUN rm -r urlproject
+# Copy config files to the image
+RUN mkdir -p /etc/urlshortener
+COPY ./configs /etc/urlshortener
 # Switch to the non-root user
 USER urlserver
 EXPOSE 8000
-CMD ["./urlshortener"]
+CMD ["./urlshortener", "-config=/etc/urlshortener/database.yaml"]

--- a/examples/docker/docker-compose.yaml
+++ b/examples/docker/docker-compose.yaml
@@ -8,6 +8,9 @@ services:
     build:
       context: ../..
       dockerfile: ./docker/Dockerfile
+    environment:
+      DB_USER: ${MYSQL_USER}
+      DB_PASSWORD: ${MYSQL_PASSWORD}
     depends_on:
       - db
     expose:

--- a/examples/docker/docker-compose.yaml
+++ b/examples/docker/docker-compose.yaml
@@ -9,8 +9,8 @@ services:
       context: ../..
       dockerfile: ./docker/Dockerfile
     environment:
-      DB_USER: ${MYSQL_USER}
-      DB_PASSWORD: ${MYSQL_PASSWORD}
+      DB_USER: root
+      DB_PASSWORD: ${MYSQL_PASSWORD:-password}
     depends_on:
       - db
     expose:
@@ -19,7 +19,7 @@ services:
     image: mysql
     restart: always
     environment:
-      MYSQL_ROOT_PASSWORD: password
+      MYSQL_ROOT_PASSWORD: ${MYSQL_PASSWORD:-password}
       MYSQL_DATABASE: url_shortener
     expose:
       - 3306

--- a/examples/windows/run.sh
+++ b/examples/windows/run.sh
@@ -1,0 +1,2 @@
+. ./examples/windows/env.cmd
+go run ./src/features/urlshortener

--- a/go.work
+++ b/go.work
@@ -1,7 +1,8 @@
 go 1.22.2
 
 use (
-	./src/libs/snowflake
-	./src/libs/utility/logger
 	./src/features/urlshortener
+	./src/libs/snowflake
+	./src/libs/utility/errutil
+	./src/libs/utility/logger
 )

--- a/src/features/urlshortener/go.mod
+++ b/src/features/urlshortener/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/gin-gonic/gin v1.9.1
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/jmoiron/sqlx v1.3.5
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -34,5 +35,4 @@ require (
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/src/features/urlshortener/infrastructure/configs.go
+++ b/src/features/urlshortener/infrastructure/configs.go
@@ -1,0 +1,10 @@
+package infrastructure
+
+type DBConfig struct {
+	Host     string
+	Port     int
+	User     string
+	Password string
+	Database string
+	Driver   string
+}

--- a/src/features/urlshortener/infrastructure/configs.go
+++ b/src/features/urlshortener/infrastructure/configs.go
@@ -1,10 +1,10 @@
 package infrastructure
 
 type DBConfig struct {
-	Host     string
-	Port     int
+	Host     string	`yaml:"host"`
+	Port     int 	`yaml:"port"`
 	User     string
 	Password string
-	Database string
-	Driver   string
+	Database string	`yaml:"database"`
+	Driver   string	`yaml:"driver"`
 }

--- a/src/features/urlshortener/infrastructure/mysqlurldb.go
+++ b/src/features/urlshortener/infrastructure/mysqlurldb.go
@@ -4,16 +4,36 @@ import (
 	"fmt"
 	"logger"
 	"reflect"
+	"strings"
 	"urlshortener/interfaces/models"
 	"urlshortener/interfaces/schemas"
-	"strings"
 
+	"github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
 )
 
 type MySQLURLDBHandler struct {
 	Conn   *sqlx.DB
 	Logger logger.Logger
+}
+
+// Initialize mysql url database
+func (dbHandler *MySQLURLDBHandler) Init() {
+	// * create url table
+	// TODO: refactor the sql statement to better write style
+	var schema = `
+	CREATE TABLE url_shortener.urlmappings (
+		id BIGINT NOT NULL AUTO_INCREMENT,
+		shortURL VARCHAR(64) NULL,
+		longURL VARCHAR(2048) NULL,
+		PRIMARY KEY (id))`
+
+	_, err := dbHandler.Conn.Exec(schema)
+	// * check if table is created
+	if err != nil && !(&mysql.MySQLError{Number: 1050}).Is(err) {
+		// * panic if error not caused by table already created
+		panic(err.Error())
+	}
 }
 
 // Implmentation of URL insert operation

--- a/src/features/urlshortener/infrastructure/mysqlurldb.go
+++ b/src/features/urlshortener/infrastructure/mysqlurldb.go
@@ -18,7 +18,7 @@ type MySQLURLDBHandler struct {
 }
 
 // Initialize mysql url database
-func (dbHandler *MySQLURLDBHandler) Init() {
+func (dbHandler *MySQLURLDBHandler) Init() error {
 	// * create url table
 	// TODO: refactor the sql statement to better write style
 	var schema = `
@@ -31,8 +31,8 @@ func (dbHandler *MySQLURLDBHandler) Init() {
 	_, err := dbHandler.Conn.Exec(schema)
 	// * check if table is created
 	if err != nil && !(&mysql.MySQLError{Number: 1050}).Is(err) {
-		// * panic if error not caused by table already created
-		panic(err.Error())
+		// * return if error not caused by table already created
+		return fmt.Errorf("Failed to create url table: %v", err)
 	}
 }
 

--- a/src/features/urlshortener/infrastructure/mysqlurldb.go
+++ b/src/features/urlshortener/infrastructure/mysqlurldb.go
@@ -34,6 +34,8 @@ func (dbHandler *MySQLURLDBHandler) Init() error {
 		// * return if error not caused by table already created
 		return fmt.Errorf("Failed to create url table: %v", err)
 	}
+
+	return nil
 }
 
 // Implmentation of URL insert operation

--- a/src/features/urlshortener/main.go
+++ b/src/features/urlshortener/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errutil"
+	"flag"
 	"fmt"
 	"logger"
 	"os"
@@ -20,9 +21,13 @@ import (
 	handlers "urlshortener/interfaces/rest/handlers"
 )
 
+var configPath = flag.String("config", "./configs/database.yaml", "config files path")
+
 func main() {
+	flag.Parse()
+
 	// * load configs
-	dbConfig, err := loadConfigs()
+	dbConfig, err := loadConfigs(*configPath)
 	println("Load config success!")
 	errutil.PanicIfError(err)
 
@@ -48,11 +53,11 @@ func main() {
 
 // TODO: maybe we can refactor these setup/init functions with better code style
 
-func loadConfigs() (infrastructure.DBConfig, error) {
+func loadConfigs(configPath string) (infrastructure.DBConfig, error) {
 	var dbConfig infrastructure.DBConfig
 
 	// * load config files
-	cfgFile, err := os.ReadFile("configs/database.yaml")
+	cfgFile, err := os.ReadFile(configPath)
 	if err != nil {
 		return dbConfig, fmt.Errorf("Failed to read database yaml: %v", err)
 	}

--- a/src/libs/utility/errutil/go.mod
+++ b/src/libs/utility/errutil/go.mod
@@ -1,0 +1,3 @@
+module errutil
+
+go 1.22.2

--- a/src/libs/utility/errutil/panic.go
+++ b/src/libs/utility/errutil/panic.go
@@ -1,0 +1,7 @@
+package errutil
+
+func PanicIfError(err error) {
+	if err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
### refactor database configs to yaml file

- original design

    Write some configs just in code like: `resource="database:8080@tcp(user:pass)/url`
- new design

    refactor these to yaml like
    #### database.yaml
    ```yaml
    host:     "db"
    port:     3306
    user:     ${DB_USER}
    password: ${DB_PASSWORD}
    database: "url_shortener"
    driver:   "mysql"
    ```

### How to test

You can test this example by
#### docker
- `sh .\example\docker\docker-run.sh` in windows command line terminal.

or
#### windows
- `sh .\example\windows\run.sh` in windows command line terminal.