### PR TITLE
hotfix: fix url query code not fetch all fields

### DIFF
--- a/src/libs/utility/dbutil/field.go
+++ b/src/libs/utility/dbutil/field.go
@@ -11,9 +11,7 @@ func FieldString(fieldStruct interface{}) string {
 	fieldArray := make([]string, 0)
 	// * iterate all fields, if not empty, append to filterStrings
 	for i := 0; i < fields.NumField(); i++ {
-		if !fields.Field(i).IsZero() {
-			fieldArray = append(fieldArray, types.Field(i).Tag.Get("db"))
-		}
+		fieldArray = append(fieldArray, types.Field(i).Tag.Get("db"))
 	}
 	return strings.Join(fieldArray, ", ")
 }


### PR DESCRIPTION
### Fix url query code not parse all fields

- Facing Bug / Problem
    > Get empty shortURL when use get API or POST a exist longURL

- How to reproduce
    - POST **createShorten** api two times and see the response
    - GET any exist shorten URL

- Solution
    - Fix wrong logic in `dbutil` custom lib