### PR TITLE
Feature: Remove logger in multiple layers

### DIFF
--- a/src/features/urlshortener/interfaces/repositories/url.go
+++ b/src/features/urlshortener/interfaces/repositories/url.go
@@ -1,7 +1,7 @@
 package repositories
 
 import (
-	"logger"
+	"fmt"
 	"urlshortener/domain"
 	"urlshortener/interfaces/models"
 )
@@ -15,7 +15,6 @@ type URLDBHandler interface {
 // class that act as a interface between application and database
 type URLRepository struct {
 	DBHandler URLDBHandler
-	Logger    logger.Logger
 }
 
 // store url entry into database
@@ -27,8 +26,7 @@ func (repo *URLRepository) Store(urlEntry domain.URLEntry) error {
 
 	err := repo.DBHandler.Insert(entry)
 	if err != nil {
-		repo.Logger.Log(err.Error())
-		return err
+		return fmt.Errorf("Fail when insert url entry from db handler: %v", err)
 	}
 	return nil
 }
@@ -42,8 +40,7 @@ func (repo *URLRepository) Get(query domain.URLEntry) (domain.URLEntry, error) {
 
 	result, err := repo.DBHandler.Query(queryModel)
 	if err != nil {
-		repo.Logger.Log(err.Error())
-		return domain.URLEntry{}, err
+		return domain.URLEntry{}, fmt.Errorf("Fail when query url entry from db handler: %v", err)
 	}
 
 	entry := domain.URLEntry{

--- a/src/features/urlshortener/interfaces/rest/handlers/urlshorten.go
+++ b/src/features/urlshortener/interfaces/rest/handlers/urlshorten.go
@@ -1,7 +1,7 @@
 package handlers
 
 import (
-	"logger"
+	"fmt"
 	"net/http"
 	schemas "urlshortener/interfaces/schemas/api"
 	"urlshortener/services"
@@ -12,7 +12,6 @@ import (
 // class to handle url shorten tasks
 type URLHandler struct {
 	URLInteractor services.URLEntryInteractor
-	Logger        logger.Logger
 }
 
 // Create a new url entry
@@ -20,13 +19,15 @@ func (handler *URLHandler) CreateURLHandler(c *gin.Context) {
 	var request schemas.CreateURLRequest
 	// Call BindJSON to bind the received JSON request
 	if err := c.Bind(&request); err != nil {
-		handler.Logger.Log(err.Error())
+		msg := fmt.Sprintf("Invalid request format: %v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
 		return
 	}
 
 	shortURL, err := handler.URLInteractor.CreateEntry(request.LongURL)
 	if err != nil {
-		handler.Logger.Log(err.Error())
+		msg := fmt.Sprintf("Internal server error: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
 		return
 	}
 
@@ -43,7 +44,8 @@ func (handler *URLHandler) GetURLHandler(c *gin.Context) {
 
 	longURL, err := handler.URLInteractor.GetURL(shortURL)
 	if err != nil {
-		_ = handler.Logger.Log(err.Error())
+		msg := fmt.Sprintf("Internal server error: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
 		return
 	}
 

--- a/src/features/urlshortener/main.go
+++ b/src/features/urlshortener/main.go
@@ -5,7 +5,6 @@ import (
 	"errutil"
 	"flag"
 	"fmt"
-	"logger"
 	"os"
 	"urlshortener/domain"
 	"urlshortener/infrastructure"
@@ -74,7 +73,7 @@ func loadConfigs(configPath string) (infrastructure.DBConfig, infrastructure.Poo
 }
 
 func initDB(dbConfig infrastructure.DBConfig, poolConfig infrastructure.PoolConfig) (*infrastructure.MySQLURLDBHandler, error) {
-	dbHandler := &infrastructure.MySQLURLDBHandler{Logger: &logger.SimpleStdLogger{}}
+	dbHandler := &infrastructure.MySQLURLDBHandler{}
 	err := dbHandler.Init(dbConfig, poolConfig)
 	if err != nil {
 		return nil, fmt.Errorf("Fail to initialize url db: %v", err)
@@ -91,13 +90,10 @@ func initNode() (*snowflake.Node, error) {
 }
 
 func createHandler(dbHandler repositories.URLDBHandler, snowflake domain.SnowFlake) *handlers.URLHandler {
-	logger := &logger.SimpleStdLogger{}
-
-	urlRepo := &repositories.URLRepository{DBHandler: dbHandler, Logger: logger}
+	urlRepo := &repositories.URLRepository{DBHandler: dbHandler}
 	hashGen := &domain.SnowFlakeHashGenerator{IDGenerator: snowflake}
-	urlItr := services.URLEntryInteractor{URLRepository: urlRepo, HashGenerator: hashGen, Logger: logger}
-
-	return &handlers.URLHandler{URLInteractor: urlItr, Logger: logger}
+	urlItr := services.URLEntryInteractor{URLRepository: urlRepo, HashGenerator: hashGen}
+	return &handlers.URLHandler{URLInteractor: urlItr}
 }
 
 func SetupRouter(middlewares []gin.HandlerFunc, handler *handlers.URLHandler) *gin.Engine {


### PR DESCRIPTION
### Changes
#### Remove logger in infra, usecase, interface layers

- return wrapped error instead
- return wrapped error and correspond http status(error) to response

### You can test this example by
#### docker
- `sh .\example\docker\docker-run.sh` in windows command line terminal.

or
#### windows
- `sh .\example\windows\run.sh` in windows command line terminal.